### PR TITLE
Reloads IFrame after opening the widget

### DIFF
--- a/packages/lab/src/preview.ts
+++ b/packages/lab/src/preview.ts
@@ -113,6 +113,7 @@ export class RisePreview extends DocumentWidget<IFrame, INotebookModel> {
     if (context) {
       this.toolbar.addItem('renderOnSave', renderOnSaveCheckbox);
       void context.ready.then(() => {
+        this.setActiveCellIndex(0);
         context.fileChanged.connect(() => {
           if (this.renderOnSave) {
             this.reload();


### PR DESCRIPTION
Fixes #17 

When opening the RisePreview directly from the file browser, we are not loading the content. This fixes it.