### PR TITLE
Change document name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,165 +1,165 @@
 {
-  "name": "jupyterlab-rise-meta",
-  "version": "0.40.0",
-  "description": "RISE: \"Live\" Reveal.js JupyterLab Slideshow extension.",
-  "keywords": [
-    "jupyter",
-    "jupyterlab",
-    "jupyterlab-extension"
-  ],
-  "private": true,
-  "files": [],
-  "workspaces": {
-    "packages": [
-      "app",
-      "ui-tests",
-      "packages/*"
-    ]
-  },
-  "homepage": "https://github.com/jupyterlab-contrib/rise",
-  "bugs": {
-    "url": "https://github.com/jupyterlab-contrib/rise/issues"
-  },
-  "license": "BSD-3-Clause",
-  "author": {
-    "name": "Frederic Collonval",
-    "email": "fcollonval@gmail.com"
-  },
-  "contributors": [
-    {
-      "name": "Thierry Parmentelat",
-      "url": "https://github.com/parmentelat"
+    "name": "jupyterlab-rise-meta",
+    "version": "0.40.0",
+    "description": "RISE: \"Live\" Reveal.js JupyterLab Slideshow extension.",
+    "keywords": [
+        "jupyter",
+        "jupyterlab",
+        "jupyterlab-extension"
+    ],
+    "private": true,
+    "files": [],
+    "workspaces": {
+        "packages": [
+            "app",
+            "ui-tests",
+            "packages/*"
+        ]
     },
-    {
-      "name": "Yiqin Zhang"
-    }
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab-contrib/rise.git"
-  },
-  "scripts": {
-    "build": "lerna run build",
-    "build:prod": "lerna run build:prod",
-    "clean": "lerna run clean",
-    "eslint": "jlpm eslint:check --fix",
-    "eslint:check": "eslint . --cache --ext .ts,.tsx",
-    "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
-    "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
-    "prettier": "jlpm prettier:base --write --list-different",
-    "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
-    "prettier:check": "jlpm prettier:base --check",
-    "stylelint": "jlpm stylelint:check --fix",
-    "stylelint:check": "stylelint --cache \"packages/*/style/**/*.css\"",
-    "watch": "run-p watch:lib watch:app",
-    "watch:app": "lerna exec --stream --scope \"rise-app\" yarn watch",
-    "watch:lib": "lerna exec --stream --scope \"jupyterlab-rise-application\" --scope \"jupyterlab-rise\" yarn watch"
-  },
-  "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^6.1.0",
-    "@typescript-eslint/parser": "^6.1.0",
-    "eslint": "^8.45.0",
-    "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-prettier": "^5.0.0",
-    "lerna": "^7.1.0",
-    "npm-run-all": "^4.1.5",
-    "prettier": "^3.0.0",
-    "rimraf": "^5.0.0",
-    "stylelint": "^15.10.1",
-    "stylelint-config-recommended": "^13.0.0",
-    "stylelint-config-standard": "^34.0.0",
-    "stylelint-prettier": "^4.0.0",
-    "typescript": "~5.0.4"
-  },
-  "eslintIgnore": [
-    "app/build",
-    "node_modules",
-    "dist",
-    "coverage",
-    "**/*.d.ts",
-    "tests",
-    "**/__tests__",
-    "ui-tests"
-  ],
-  "eslintConfig": {
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:prettier/recommended"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "project": "tsconfig.eslint.json",
-      "sourceType": "module"
+    "homepage": "https://github.com/jupyterlab-contrib/rise",
+    "bugs": {
+        "url": "https://github.com/jupyterlab-contrib/rise/issues"
     },
-    "plugins": [
-      "@typescript-eslint"
+    "license": "BSD-3-Clause",
+    "author": {
+        "name": "Frederic Collonval",
+        "email": "fcollonval@gmail.com"
+    },
+    "contributors": [
+        {
+            "name": "Thierry Parmentelat",
+            "url": "https://github.com/parmentelat"
+        },
+        {
+            "name": "Yiqin Zhang"
+        }
     ],
-    "rules": {
-      "@typescript-eslint/naming-convention": [
-        "error",
-        {
-          "selector": "interface",
-          "format": [
-            "PascalCase"
-          ],
-          "custom": {
-            "regex": "^I[A-Z]",
-            "match": true
-          }
-        }
-      ],
-      "@typescript-eslint/no-unused-vars": [
-        "warn",
-        {
-          "args": "none"
-        }
-      ],
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-namespace": "off",
-      "@typescript-eslint/no-use-before-define": "off",
-      "@typescript-eslint/quotes": [
-        "error",
-        "single",
-        {
-          "avoidEscape": true,
-          "allowTemplateLiterals": false
-        }
-      ],
-      "curly": [
-        "error",
-        "all"
-      ],
-      "eqeqeq": "error",
-      "prefer-arrow-callback": "error"
-    }
-  },
-  "prettier": {
-    "singleQuote": true,
-    "trailingComma": "none",
-    "arrowParens": "avoid",
-    "endOfLine": "auto",
-    "overrides": [
-      {
-        "files": "package.json",
-        "options": {
-          "tabWidth": 4
-        }
-      }
-    ]
-  },
-  "stylelint": {
-    "extends": [
-      "stylelint-config-recommended",
-      "stylelint-config-standard",
-      "stylelint-prettier/recommended"
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/jupyterlab-contrib/rise.git"
+    },
+    "scripts": {
+        "build": "lerna run build",
+        "build:prod": "lerna run build:prod",
+        "clean": "lerna run clean",
+        "eslint": "jlpm eslint:check --fix",
+        "eslint:check": "eslint . --cache --ext .ts,.tsx",
+        "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
+        "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
+        "prettier": "jlpm prettier:base --write --list-different",
+        "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+        "prettier:check": "jlpm prettier:base --check",
+        "stylelint": "jlpm stylelint:check --fix",
+        "stylelint:check": "stylelint --cache \"packages/*/style/**/*.css\"",
+        "watch": "run-p watch:lib watch:app",
+        "watch:app": "lerna exec --stream --scope \"rise-app\" yarn watch",
+        "watch:lib": "lerna exec --stream --scope \"jupyterlab-rise-application\" --scope \"jupyterlab-rise\" yarn watch"
+    },
+    "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.1.0",
+        "@typescript-eslint/parser": "^6.1.0",
+        "eslint": "^8.45.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "lerna": "^7.1.0",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^3.0.0",
+        "rimraf": "^5.0.0",
+        "stylelint": "^15.10.1",
+        "stylelint-config-recommended": "^13.0.0",
+        "stylelint-config-standard": "^34.0.0",
+        "stylelint-prettier": "^4.0.0",
+        "typescript": "~5.0.4"
+    },
+    "eslintIgnore": [
+        "app/build",
+        "node_modules",
+        "dist",
+        "coverage",
+        "**/*.d.ts",
+        "tests",
+        "**/__tests__",
+        "ui-tests"
     ],
-    "rules": {
-      "property-no-vendor-prefix": null,
-      "selector-class-pattern": null,
-      "selector-no-vendor-prefix": null,
-      "value-no-vendor-prefix": null
+    "eslintConfig": {
+        "extends": [
+            "eslint:recommended",
+            "plugin:@typescript-eslint/eslint-recommended",
+            "plugin:@typescript-eslint/recommended",
+            "plugin:prettier/recommended"
+        ],
+        "parser": "@typescript-eslint/parser",
+        "parserOptions": {
+            "project": "tsconfig.eslint.json",
+            "sourceType": "module"
+        },
+        "plugins": [
+            "@typescript-eslint"
+        ],
+        "rules": {
+            "@typescript-eslint/naming-convention": [
+                "error",
+                {
+                    "selector": "interface",
+                    "format": [
+                        "PascalCase"
+                    ],
+                    "custom": {
+                        "regex": "^I[A-Z]",
+                        "match": true
+                    }
+                }
+            ],
+            "@typescript-eslint/no-unused-vars": [
+                "warn",
+                {
+                    "args": "none"
+                }
+            ],
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-namespace": "off",
+            "@typescript-eslint/no-use-before-define": "off",
+            "@typescript-eslint/quotes": [
+                "error",
+                "single",
+                {
+                    "avoidEscape": true,
+                    "allowTemplateLiterals": false
+                }
+            ],
+            "curly": [
+                "error",
+                "all"
+            ],
+            "eqeqeq": "error",
+            "prefer-arrow-callback": "error"
+        }
+    },
+    "prettier": {
+        "singleQuote": true,
+        "trailingComma": "none",
+        "arrowParens": "avoid",
+        "endOfLine": "auto",
+        "overrides": [
+            {
+                "files": "package.json",
+                "options": {
+                    "tabWidth": 4
+                }
+            }
+        ]
+    },
+    "stylelint": {
+        "extends": [
+            "stylelint-config-recommended",
+            "stylelint-config-standard",
+            "stylelint-prettier/recommended"
+        ],
+        "rules": {
+            "property-no-vendor-prefix": null,
+            "selector-class-pattern": null,
+            "selector-no-vendor-prefix": null,
+            "value-no-vendor-prefix": null
+        }
     }
-  }
 }

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -103,7 +103,7 @@ const plugin: JupyterFrontEndPlugin<IRisePreviewTracker> = {
     }
 
     const factory = new RisePreviewFactory(getRiseUrl, commands, {
-      name: 'rise',
+      name: 'Rise Slides',
       fileTypes: ['notebook'],
       modelName: 'notebook'
     });

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -103,7 +103,8 @@ const plugin: JupyterFrontEndPlugin<IRisePreviewTracker> = {
     }
 
     const factory = new RisePreviewFactory(getRiseUrl, commands, {
-      name: 'Rise Slides',
+      name: 'rise',
+      label: trans.__('Rise Slides'),
       fileTypes: ['notebook'],
       modelName: 'notebook'
     });


### PR DESCRIPTION
Fixes document label as commented in https://github.com/jupyterlab-contrib/rise/pull/35#issuecomment-1644081589

> Btw: if easy to change, "Rise Slides" or "Slides (Rise)" or "Slides" would be more informative as label in the menu
for users that don't know that rise is a tool for slides.

cc @nthiery 


![Screenshot from 2023-09-04 10-51-44](https://github.com/jupyterlab-contrib/rise/assets/26092748/93feebbc-da3f-46e5-8a7e-c29e5c77e0de)
