### PR TITLE
Move token to its own file

### DIFF
--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -89,7 +89,12 @@ export const plugin: JupyterFrontEndPlugin<void> = {
       app.restored
     ]).then(async ([settings]) => {
       const notebookPath = PageConfig.getOption('notebookPath');
-      const notebookPanel = documentManager.open(notebookPath) as NotebookPanel;
+      const notebookPanel = (documentManager.open(notebookPath, 'Notebook') ??
+        // If the file cannot be opened with the Notebook factory, try jupytext
+        documentManager.open(
+          notebookPath,
+          'Jupytext Notebook'
+        )) as NotebookPanel;
       // With the new windowing, some cells are not visible and we need
       // to deactivate the windowing and wait for each cell to be ready.
       notebookPanel.content.notebookConfig = {

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -55,6 +55,7 @@
     "@lumino/coreutils": "^2.0.0",
     "@lumino/disposable": "^2.0.0",
     "@lumino/messaging": "^2.0.0",
+    "@lumino/signaling": "^2.0.0",
     "@lumino/widgets": "^2.0.1"
   },
   "devDependencies": {

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -32,13 +32,10 @@ import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 
 import { fullScreenIcon, RISEIcon } from './icons';
 
-import {
-  RisePreview,
-  IRisePreviewTracker,
-  RisePreviewFactory
-} from './preview';
+import { RisePreview, RisePreviewFactory } from './preview';
+import { IRisePreviewTracker } from './tokens';
 
-export { IRisePreviewTracker } from './preview';
+export { IRisePreviewTracker } from './tokens';
 
 /**
  * Command IDs namespace for JupyterLab RISE extension

--- a/packages/lab/src/preview.ts
+++ b/packages/lab/src/preview.ts
@@ -239,6 +239,13 @@ export namespace RisePreview {
     renderOnSave?: boolean;
   }
 
+  /**
+   * Generate the URL required to open a file as RISE slideshow.
+   *
+   * @param path File path
+   * @param activeCellIndex Active cell index
+   * @returns URL to open
+   */
   export function getRiseUrl(path: string, activeCellIndex?: number): string {
     const baseUrl = PageConfig.getBaseUrl();
     let url = `${baseUrl}rise/${path}`;
@@ -248,6 +255,9 @@ export namespace RisePreview {
     return url;
   }
 
+  /**
+   * RISE Preview document factory token implementation.
+   */
   export class FactoryToken implements IRisePreviewFactory {
     constructor({
       commands,
@@ -268,6 +278,14 @@ export namespace RisePreview {
       this._updateFactory();
     }
 
+    /**
+     * Add a new file type to the RISE preview factory.
+     *
+     * #### Notes
+     * Useful to add file types for jupytext.
+     *
+     * @param ft File type
+     */
     addFileType(ft: string): void {
       if (!this._fileTypes.includes(ft)) {
         this._fileTypes.push(ft);
@@ -275,6 +293,9 @@ export namespace RisePreview {
       }
     }
 
+    /**
+     * Signal emitted when a RISE preview is created.
+     */
     get widgetCreated(): ISignal<IRisePreviewFactory, RisePreview> {
       return this._widgetCreated;
     }
@@ -312,6 +333,9 @@ export namespace RisePreview {
   }
 }
 
+/**
+ * RISE Preview widget factory
+ */
 export class RisePreviewFactory extends ABCWidgetFactory<
   RisePreview,
   INotebookModel

--- a/packages/lab/src/preview.ts
+++ b/packages/lab/src/preview.ts
@@ -1,9 +1,4 @@
-import {
-  IFrame,
-  ToolbarButton,
-  IWidgetTracker,
-  Toolbar
-} from '@jupyterlab/apputils';
+import { IFrame, ToolbarButton, Toolbar } from '@jupyterlab/apputils';
 
 import {
   ABCWidgetFactory,
@@ -19,7 +14,7 @@ import { refreshIcon } from '@jupyterlab/ui-components';
 
 import { CommandRegistry } from '@lumino/commands';
 
-import { PromiseDelegate, Token } from '@lumino/coreutils';
+import { PromiseDelegate } from '@lumino/coreutils';
 
 import { Message } from '@lumino/messaging';
 
@@ -28,19 +23,6 @@ import { Signal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 
 import { fullScreenIcon, RISEIcon } from './icons';
-
-/**
- * A class that tracks Rise Preview widgets.
- */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IRisePreviewTracker extends IWidgetTracker<RisePreview> {}
-
-/**
- * The Rise Preview tracker token.
- */
-export const IRisePreviewTracker = new Token<IRisePreviewTracker>(
-  'jupyterlab-rise:IRisePreviewTracker'
-);
 
 /**
  * A DocumentWidget that shows a Rise preview in an IFrame.

--- a/packages/lab/src/tokens.ts
+++ b/packages/lab/src/tokens.ts
@@ -18,15 +18,26 @@ export const IRisePreviewTracker = new Token<IRisePreviewTracker>(
 );
 
 /**
- *
+ * RISE Preview document factory interface
  */
 export interface IRisePreviewFactory {
+  /**
+   * Signal emitted when a RISE preview is created.
+   */
   readonly widgetCreated: ISignal<IRisePreviewFactory, RisePreview>;
+  /**
+   * Add a new file type to the RISE preview factory.
+   *
+   * #### Notes
+   * Useful to add file types for jupytext.
+   *
+   * @param ft File type
+   */
   addFileType(ft: string): void;
 }
 
 /**
- *
+ * RISE Preview factory token.
  */
 export const IRisePreviewFactory = new Token<IRisePreviewFactory>(
   'jupyterlab-rise:IRisePreviewFactory',

--- a/packages/lab/src/tokens.ts
+++ b/packages/lab/src/tokens.ts
@@ -1,0 +1,16 @@
+import { IWidgetTracker } from '@jupyterlab/apputils';
+import { Token } from '@lumino/coreutils';
+import type { RisePreview } from './preview';
+
+/**
+ * A class that tracks Rise Preview widgets.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IRisePreviewTracker extends IWidgetTracker<RisePreview> {}
+
+/**
+ * The Rise Preview tracker token.
+ */
+export const IRisePreviewTracker = new Token<IRisePreviewTracker>(
+  'jupyterlab-rise:IRisePreviewTracker'
+);

--- a/packages/lab/src/tokens.ts
+++ b/packages/lab/src/tokens.ts
@@ -1,5 +1,6 @@
 import { IWidgetTracker } from '@jupyterlab/apputils';
 import { Token } from '@lumino/coreutils';
+import { ISignal } from '@lumino/signaling';
 import type { RisePreview } from './preview';
 
 /**
@@ -12,5 +13,22 @@ export interface IRisePreviewTracker extends IWidgetTracker<RisePreview> {}
  * The Rise Preview tracker token.
  */
 export const IRisePreviewTracker = new Token<IRisePreviewTracker>(
-  'jupyterlab-rise:IRisePreviewTracker'
+  'jupyterlab-rise:IRisePreviewTracker',
+  'Adds a tracker for RISE slides preview widgets.'
+);
+
+/**
+ *
+ */
+export interface IRisePreviewFactory {
+  readonly widgetCreated: ISignal<IRisePreviewFactory, RisePreview>;
+  addFileType(ft: string): void;
+}
+
+/**
+ *
+ */
+export const IRisePreviewFactory = new Token<IRisePreviewFactory>(
+  'jupyterlab-rise:IRisePreviewFactory',
+  'Customize the RISE slides preview factory.'
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9555,6 +9555,7 @@ __metadata:
     "@lumino/coreutils": ^2.0.0
     "@lumino/disposable": ^2.0.0
     "@lumino/messaging": ^2.0.0
+    "@lumino/signaling": ^2.0.0
     "@lumino/widgets": ^2.0.1
     rimraf: ~5.0.0
     typescript: ~5.0.4


### PR DESCRIPTION
This:

* will improve tree shaking when only requiring the token.
* add a new token to customize the widget factory (for use in Jupytext)

Fixes partly https://github.com/jupyterlab-contrib/rise/issues/17#issuecomment-1699442075 cc @nthiery 

This will need to be backported on 3.x and then a PR will be required on jupytext itself (code already written and tested https://github.com/fcollonval/jupytext/tree/ft/support-lab-rise).