### PR TITLE
Fix keys being captured when in edit mode

### DIFF
--- a/packages/lab/schema/plugin.json
+++ b/packages/lab/schema/plugin.json
@@ -56,12 +56,12 @@
     {
       "command": "RISE:toggleOverview",
       "keys": ["W"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.slides.jp-mod-commandMode"
     },
     {
       "command": "RISE:toggleAllRiseButtons",
       "keys": [","],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.slides.jp-mod-commandMode"
     },
     {
       "command": "RISE:fullscreenHelp",
@@ -71,47 +71,47 @@
     {
       "command": "RISE:riseHelp",
       "keys": ["?"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.slides.jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-clear",
       "keys": ["minus"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.slides.jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-reset",
       "keys": ["="],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.slides.jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-toggleChalkboard",
       "keys": ["["],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.slides.jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-toggleNotesCanvas",
       "keys": ["]"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.slides.jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-colorPrev",
       "keys": ["Q"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.slides.jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-colorNext",
       "keys": ["S"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.slides.jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-download",
       "keys": ["\\"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.slides.jp-mod-commandMode"
     },
     {
       "command": "RISE:notes-open",
       "keys": ["T"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.slides.jp-mod-commandMode"
     },
     {
       "command": "RISE:smart-exec",


### PR DESCRIPTION
Hello,

This PR is an attempt to fix #33. 

What I found was that shortcuts listed in packages/lab/schema/plugin.json have selectors that target .lm-Widget.reveal which doesn't account for whether or not a slide is in edit or command mode, meaning the keys are captured even when the cell is being actively edited. 

The selectors now target .lm-Widget.slides.jp-mod-commandMode which only exists when the slide is in command mode.

Thank you.