### PR TITLE
Fix Custom CSS URL Possible Double Slash

### DIFF
--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -901,7 +901,10 @@ namespace Rise {
     // https://github.com/jupyterlab-contrib/rise/issues/509
     // Attempt to load rise.css
     const curdir = PathExt.dirname(panel.sessionContext.path);
-    const riseCssUrl = new URL(PathExt.join("files", curdir, "rise.css"), PageConfig.getBaseUrl());
+    const riseCssUrl = new URL(
+      PathExt.join('files', curdir, 'rise.css'),
+      PageConfig.getBaseUrl()
+    );
     document.head.insertAdjacentHTML(
       'beforeend',
       `<link rel="stylesheet" href="${riseCssUrl.href}" id="rise-custom-css" />`
@@ -910,7 +913,10 @@ namespace Rise {
     const dot_index = name.lastIndexOf('.');
     const stem = dot_index === -1 ? name : name.substr(0, dot_index);
     // associated css
-    const nameCssUrl = new URL(PathExt.join("files", curdir, `${stem}.css`), PageConfig.getBaseUrl());
+    const nameCssUrl = new URL(
+      PathExt.join('files', curdir, `${stem}.css`),
+      PageConfig.getBaseUrl()
+    );
     // Attempt to load css with the same path as notebook
     document.head.insertAdjacentHTML(
       'beforeend',

--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -901,19 +901,20 @@ namespace Rise {
     // https://github.com/jupyterlab-contrib/rise/issues/509
     // Attempt to load rise.css
     const curdir = PathExt.dirname(panel.sessionContext.path);
+    const riseCssUrl = new URL(PathExt.join("files", curdir, "rise.css"), PageConfig.getBaseUrl());
     document.head.insertAdjacentHTML(
       'beforeend',
-      `<link rel="stylesheet" href="${PageConfig.getBaseUrl()}files/${curdir}/rise.css" id="rise-custom-css" />`
+      `<link rel="stylesheet" href="${riseCssUrl.href}" id="rise-custom-css" />`
     );
     const name = PathExt.basename(panel.sessionContext.path);
     const dot_index = name.lastIndexOf('.');
     const stem = dot_index === -1 ? name : name.substr(0, dot_index);
     // associated css
-    const name_css = `${curdir}/${stem}.css`;
+    const nameCssUrl = new URL(PathExt.join("files", curdir, `${stem}.css`), PageConfig.getBaseUrl());
     // Attempt to load css with the same path as notebook
     document.head.insertAdjacentHTML(
       'beforeend',
-      `<link rel="stylesheet" href="${PageConfig.getBaseUrl()}files/${name_css}" id="rise-notebook-css" />`
+      `<link rel="stylesheet" href="${nameCssUrl.href}" id="rise-notebook-css" />`
     );
 
     // Asynchronously import reveal


### PR DESCRIPTION
This PR fixes custom CSS HTTP request errors when starting JupyterLab server with the same folder as the `.ipynb` file.

Fixes https://github.com/jupyterlab-contrib/rise/issues/27

Example URL: `http://localhost:8888/files//rise.css`
```
403 : Forbidden
The error was:

/rise.css is not in root static directory
```