### PR TITLE
Fix the shortcut triggered in edit mode

### DIFF
--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -883,10 +883,33 @@ namespace Rise {
   ): Promise<void> {
     document.body.classList.add('rise-enabled');
 
+    // Allow the panel to receive focus, to send it to the notebook.
+    // NOTES:
+    // Clicking in the notebook panel seems to fallback on reveal background,
+    // which gives the focus to the body element (at least it is the one targeted
+    // when using `document.activeElement`), without triggering the onfocus event.
+    panel.node.tabIndex = -1;
+
     // Add the main reveal.js classes
     const notebook = panel.content;
     panel.addClass('reveal');
     notebook.addClass('slides');
+
+    // Move the focus to the notebook when the iframe get the focus.
+    document.body.onfocus = event => {
+      const target = event.target;
+      if (target instanceof Window) {
+        notebook.node.focus();
+      }
+    };
+
+    // Move the focus to the notebook when the panel get the focus.
+    panel.node.onfocus = event => {
+      const target = event.target as HTMLElement;
+      if (!notebook.node.contains(target)) {
+        notebook.node.focus();
+      }
+    };
 
     // Header
     // Available themes are in static/css/theme

--- a/packages/lab/schema/plugin.json
+++ b/packages/lab/schema/plugin.json
@@ -46,22 +46,22 @@
     {
       "command": "RISE:firstSlide",
       "keys": ["Home"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:lastSlide",
       "keys": ["End"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:toggleOverview",
       "keys": ["W"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:toggleAllRiseButtons",
       "keys": [","],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:fullscreenHelp",
@@ -71,47 +71,47 @@
     {
       "command": "RISE:riseHelp",
       "keys": ["?"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-clear",
       "keys": ["minus"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-reset",
       "keys": ["="],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-toggleChalkboard",
       "keys": ["["],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-toggleNotesCanvas",
       "keys": ["]"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-colorPrev",
       "keys": ["Q"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-colorNext",
       "keys": ["S"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-download",
       "keys": ["\\"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:notes-open",
       "keys": ["T"],
-      "selector": ".lm-Widget.reveal"
+      "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:smart-exec",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15396,21 +15396,21 @@ __metadata:
 
 "typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>":
   version: 5.1.6
-  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"
+  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f53bfe97f7c8b2b6d23cf572750d4e7d1e0c5fff1c36d859d0ec84556a827b8785077bc27676bf7e71fae538e517c3ecc0f37e7f593be913d884805d931bc8be
+  checksum: 21e88b0a0c0226f9cb9fd25b9626fb05b4c0f3fddac521844a13e1f30beb8f14e90bd409a9ac43c812c5946d714d6e0dee12d5d02dfc1c562c5aacfa1f49b606
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
+  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes #33 by changing the command selectors to the notebook in command mode.

It supersedes https://github.com/jupyterlab-contrib/rise/pull/58.

It also ensure the focus to the notebook node, to ensure the command are triggered when focusing the rise panel.