### PR TITLE
Add the code mirror binding plugin

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -104,6 +104,7 @@ async function main() {
     require('@jupyterlab/codemirror-extension').default.filter(({ id }) =>
       [
         '@jupyterlab/codemirror-extension:services',
+        '@jupyterlab/codemirror-extension:binding',
         '@jupyterlab/codemirror-extension:codemirror',
         '@jupyterlab/codemirror-extension:languages',
         '@jupyterlab/codemirror-extension:extensions',


### PR DESCRIPTION
This PR fixes https://github.com/jupyterlab-contrib/rise/issues/48

The plugin to bind the code-mirror editor and the cell source was missing from the application requirements.
Therefore, changes in the editor were not synchronize to the source.