### PR TITLE
Add: seaborn dependency for the binder environment.yml

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -20,3 +20,4 @@ dependencies:
   - ipywidgets
   - matplotlib-base
   - numpy
+  - seaborn


### PR DESCRIPTION
The README.md has a "launch binder" button that links to a slideshow notebook containing code that uses seaborn.