### PR TITLE
Fix dataframes and text size in slides

### DIFF
--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -204,7 +204,7 @@
 }
 
 .rise-enabled .jp-InputArea pre {
-  font-size: 1.25rem;
+  font-size: 14px;
 }
 
 .rise-enabled .jp-InputPrompt {
@@ -217,7 +217,7 @@
 }
 
 .rise-enabled .jp-OutputArea pre {
-  font-size: 1.25rem;
+  font-size: 14px;
 }
 
 .rise-enabled .jp-OutputPrompt {
@@ -251,40 +251,24 @@
   overflow-y: hidden;
 }
 
-.rise-enabled .jp-RenderedHTMLCommon p,
-.rise-enabled .jp-RenderedHTMLCommon li,
-.rise-enabled i {
-  font-size: 2.25rem;
-}
-
-/* Fix for issue 51 */
-.rise-enabled .jp-RenderedHTMLCommon table + p {
-  font-size: 14px;
-}
-
 .rise-enabled .jp-RenderedHTMLCommon h1 {
-  font-size: 4.125rem;
   font-weight: bold;
 }
 
 .rise-enabled .jp-RenderedHTMLCommon h2 {
-  font-size: 3.5rem;
   font-weight: bold;
 }
 
 .rise-enabled .jp-RenderedHTMLCommon h3 {
-  font-size: 2.9rem;
   font-weight: bold;
 }
 
 .rise-enabled .jp-RenderedHTMLCommon h4 {
-  font-size: 2.25rem;
   font-weight: bold;
   font-style: italic;
 }
 
 .rise-enabled .jp-RenderedHTMLCommon h5 {
-  font-size: 2rem;
   font-weight: bold;
   font-style: italic;
 }

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -33,6 +33,11 @@
     chalkboard options */
 }
 
+.rise-enabled .reveal table th,
+.rise-enabled .reveal table td {
+  border-bottom: none;
+}
+
 /* do not apply this on the <body> tag */
 :not(body).rise-enabled {
   background-color: #fff;
@@ -252,6 +257,11 @@
   font-size: 2.25rem;
 }
 
+/* Fix for issue 51 */
+.rise-enabled .jp-RenderedHTMLCommon table + p {
+  font-size: 14px;
+}
+
 .rise-enabled .jp-RenderedHTMLCommon h1 {
   font-size: 4.125rem;
   font-weight: bold;
@@ -410,11 +420,6 @@
 
 .rise-enabled #toggle-notes {
   left: 7em !important;
-}
-
-/* fix for issue #425 */
-.rise-enabled .jp-RenderedHTMLCommon table {
-  font-size: 75%;
 }
 
 /* fix for reveal dark themes */


### PR DESCRIPTION
Fixes issue #51

- Styling of dataframes now matches that of notebook
- Set size of headers and markdown text to a more reasonable size compared to code input so slides can be zoomed into as needed

Example before:
<img width="375" alt="image" src="https://github.com/user-attachments/assets/5734c023-5a59-4a43-bb0f-0e08a1e39951">

Example after:
<img width="375" alt="image" src="https://github.com/user-attachments/assets/0ac5b9f3-125f-47d1-b31c-a1f05bbd44e2">
