### PR TITLE
Require jupyterlab>=4.1.2 for arrow key compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ RISE: "Live" Reveal.js JupyterLab Slideshow extension.
 
 ## Requirements
 
-- JupyterLab >= 4.0.0
+- JupyterLab >= 4.1.2
 
 ## Install
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -11,7 +11,7 @@ channels:
 
 dependencies:
   # runtime dependencies
-  - jupyterlab >=4,<5.0.0a0
+  - jupyterlab >=4.1.2,<5.0.0a0
   # labextension build dependencies
   - nodejs >=18,<19
   - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.5.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version"]
+requires = ["hatchling>=1.5.0", "jupyterlab>=4.1.2,<5", "hatch-nodejs-version"]
 build-backend = "hatchling.build"
 
 [project]
@@ -22,7 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "jupyter_server>=2.0.1,<3"
+    "jupyter_server>=2.0.1,<3",
+    "jupyterlab>=4.1.2,<5"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
@@ -80,11 +81,11 @@ version-cmd = "python scripts/bump_version.py --force"
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = [
-    "python -m pip install 'jupyterlab>=4.0.0,<5'",
+    "python -m pip install 'jupyterlab>=4.1.2,<5'",
     "jlpm"
 ]
 before-build-npm = [
-    "python -m pip install 'jupyterlab>=4.0.0,<5'",
+    "python -m pip install 'jupyterlab>=4.1.2,<5'",
     "jlpm",
     "jlpm build:prod"
 ]


### PR DESCRIPTION
Addresses issue #66

As noted in the original issue, left and right arrows keys could not be used to navigate through slides as they collided with JupyterLab's keybindings for collapsing and uncollapsing headers. 

JupyterLab changed the shortcut selectors to a more specific ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus" in version 4.1.2 which appears to no longer target the RISE slideshow. Originally this was just just ".jp-Notebook:focus.jp-mod-commandMode".

To avoid people running into this issue with earlier versions of JupyterLab I added a requirement to have jupyterlab >= 4.1.2. Feel free to suggest any alternatives. Thanks.