### PR TITLE
Add jupyterlab-mathjax3 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "jupyter_server>=2.0.1,<3"
+    "jupyter_server>=2.0.1,<3",
+    "jupyterlab-mathjax3"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
Fixes issue #75 

Adds `jupyterlab-mathjax3` as a dependency so LaTeX is rendered properly in slideshow.