### PR TITLE
Added a real time font size menu (open via Shift+C shortcut)

### DIFF
--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -55,7 +55,7 @@ const style = document.createElement('style');
 function SetStyleValue(type:string, newValue:string) {
   const text = style.textContent?.replace(":root {", "")?.replace("}", "")?.replace("\n", "")?.split(";");
   
-  if(text == undefined) return;
+  if(text === undefined) return;
 
   let result = ":root {\n";
 
@@ -80,7 +80,7 @@ function SetStyleValue(type:string, newValue:string) {
 function GetStyleValue(type:string) {
   const text = style.textContent?.replace(":root {", "")?.replace("}", "")?.split(";");
   
-  if(text == undefined) return "10";
+  if(text === undefined) return "10";
 
   for (let i = 0; i < text?.length; i++) {
     let styleRule = text[i]?.trim();
@@ -977,7 +977,7 @@ namespace Rise {
           SetStyleValue("--jp-ui-table-font-size-rise", tableFontSizeData.input.value);
           SetStyleValue("--jp-ui-code-output", outputFontSizeData.input.value);
 
-          if(headerSizeData.input.value != headerSizeData.originalVal) {
+          if(headerSizeData.input.value !== headerSizeData.originalVal) {
             const headerSize = headerSizeData.input.value
             SetStyleValue("--jp-ui-font-size0-rise", headerSizeData.input.value);
             SetStyleValue("--jp-ui-font-size1-rise", (Number(headerSize) * 0.8).toString());

--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -52,13 +52,16 @@ namespace CommandIDs {
 
 const style = document.createElement('style');
 
+// Sets the value of a style variable that is active (defined in base.css)
 function SetStyleValue(type:string, newValue:string) {
+  // Get an array of css entries
   const text = style.textContent?.replace(":root {", "")?.replace("}", "")?.replace("\n", "")?.split(";");
   
   if(text === undefined) return;
 
-  let result = ":root {\n";
+  let result = ":root {\n"; // Start building new css entry
 
+  // Find entry to change and set new value
   for (let i = 0; i < text?.length; i++) {
     let styleRule = text[i]?.trim();
     
@@ -77,11 +80,14 @@ function SetStyleValue(type:string, newValue:string) {
   style.textContent = result;
 }
 
+// Returns the current value of a style variable
 function GetStyleValue(type:string) {
+  // Get an array of css entries
   const text = style.textContent?.replace(":root {", "")?.replace("}", "")?.split(";");
   
-  if(text === undefined) return "10";
+  if(text === undefined) return "10"; // Return default value if no css is found
 
+  // Loop through css entries and search for the right entry
   for (let i = 0; i < text?.length; i++) {
     let styleRule = text[i]?.trim();
     
@@ -90,9 +96,9 @@ function GetStyleValue(type:string) {
     styleRule = styleRule.replace(type + ": ", "");
     styleRule = styleRule.replace("px !important", "");
 
-    return styleRule;
+    return styleRule; // Variable found, return its value
   }
-  return "10";
+  return "10"; // Variable not found, return a default value so nothing breaks
 }
 
 /**
@@ -918,12 +924,14 @@ namespace Rise {
       );
   }
 
+  // Function to open the Font-Size-Menu
   function openFontSizeMenu() {
     const content = document.createElement('div');
       content.style.display = 'flex';
       content.style.flexDirection = 'column';
       
-      function GetAppendData(label: string, varName: string) {
+      // Helper function to get the data needed, to append an entry
+      function getAppendData(label: string, varName: string) {
         const container = document.createElement('div');
         container.style.display = 'flex';
         container.style.alignItems = 'center';
@@ -939,14 +947,16 @@ namespace Rise {
         container.appendChild(labelElem);
         container.appendChild(input);
         
-        return {container: container, input: input, label: labelElem, originalVal: input.value};
+        return {container: container, input: input, label: labelElem, originalVal: input.value}; // Return all the values needed
       }
 
-      const headerSizeData = GetAppendData("Header Font Size:", "--jp-ui-font-size0-rise");
-      const codeFontSizeData = GetAppendData("Code Font Size:", "--jp-code-font-size");
-      const outputFontSizeData = GetAppendData("Output Font Size:", "--jp-ui-code-output");
-      const tableFontSizeData = GetAppendData("Table Font Size:", "--jp-ui-table-font-size-rise");
+      // Build the window
+      const headerSizeData = getAppendData("Header Font Size:", "--jp-ui-font-size0-rise");
+      const codeFontSizeData = getAppendData("Code Font Size:", "--jp-code-font-size");
+      const outputFontSizeData = getAppendData("Output Font Size:", "--jp-ui-code-output");
+      const tableFontSizeData = getAppendData("Table Font Size:", "--jp-ui-table-font-size-rise");
 
+      // Append all values
       content.appendChild(headerSizeData.label);
       content.appendChild(headerSizeData.input);
       content.appendChild(document.createElement('br'));
@@ -962,6 +972,7 @@ namespace Rise {
       const contentWidget = new Widget();
       contentWidget.node.appendChild(content);
 
+      // Show the dialog window
       const dialog = showDialog({
         title: 'Font Size Settings',
         body: contentWidget,
@@ -971,12 +982,15 @@ namespace Rise {
         ]
       });
 
+      // Handle result
       dialog.then(result => {
         if (result.button.accept) {
+          // Set new values
           SetStyleValue("--jp-code-font-size", codeFontSizeData.input.value);
           SetStyleValue("--jp-ui-table-font-size-rise", tableFontSizeData.input.value);
           SetStyleValue("--jp-ui-code-output", outputFontSizeData.input.value);
 
+          // If header value changed, change the others accordingly
           if(headerSizeData.input.value !== headerSizeData.originalVal) {
             const headerSize = headerSizeData.input.value
             SetStyleValue("--jp-ui-font-size0-rise", headerSizeData.input.value);
@@ -987,6 +1001,7 @@ namespace Rise {
           }
         }
 
+        // Remove the window
         contentWidget.dispose();
       });
   }

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -217,7 +217,7 @@
 }
 
 .rise-enabled .jp-OutputArea pre {
-  font-size: 14px;
+  font-size: var(--jp-ui-code-output);
 }
 
 .rise-enabled .jp-OutputPrompt {
@@ -252,25 +252,30 @@
 }
 
 .rise-enabled .jp-RenderedHTMLCommon h1 {
+  font-size: var(--jp-ui-font-size0-rise);
   font-weight: bold;
 }
 
 .rise-enabled .jp-RenderedHTMLCommon h2 {
+  font-size: var(--jp-ui-font-size1-rise);
   font-weight: bold;
 }
 
 .rise-enabled .jp-RenderedHTMLCommon h3 {
+  font-size: var(--jp-ui-font-size2-rise);
   font-weight: bold;
 }
 
 .rise-enabled .jp-RenderedHTMLCommon h4 {
+  font-size: var(--jp-ui-font-size3-rise);
   font-weight: bold;
-  font-style: italic;
+  /* font-style: italic; */
 }
 
 .rise-enabled .jp-RenderedHTMLCommon h5 {
+  font-size: var(--jp-ui-font-size4-rise);
   font-weight: bold;
-  font-style: italic;
+  /* font-style: italic; */
 }
 
 .rise-enabled .CodeMirror {
@@ -404,6 +409,10 @@
 
 .rise-enabled #toggle-notes {
   left: 7em !important;
+}
+
+.rise-enabled .jp-RenderedHTMLCommon table {
+  font-size: var(--jp-ui-table-font-size-rise);
 }
 
 /* fix for reveal dark themes */

--- a/packages/lab/schema/plugin.json
+++ b/packages/lab/schema/plugin.json
@@ -117,6 +117,11 @@
       "command": "RISE:smart-exec",
       "keys": ["Shift Enter"],
       "selector": ".lm-Widget.reveal .jp-Notebook:focus"
+    },
+    {
+      "command": "RISE:change-font-size",
+      "keys": ["Shift C"],
+      "selector": ".lm-Widget.reveal .jp-Notebook:focus"
     }
   ],
   "type": "object",


### PR DESCRIPTION
Changes:
code-, code output-, header-, table font size and removed italic font from h4 and h5 in presentation mode

Implementation idea:

Sizes:
We built a menu, which can be opened with the shortcut Shift+C. In the menu, there are four different categories (code-, code output-, header-, table font size). With the menu, we want to enable individual size adjustments for each category independently.
ATTENTION: To use the shift-c shortcut you have to left-click select the current slide once. Otherwise it will not be in focus and the shortcut won't work.

Italic font:
We removed the italic font from header 4 and 5 since it was irritating in some cases for us. 

The implementation is done within rise.ts. There are some helper functions used, which we were not sure where to place. If you want them somewhere else please let us know and we can fix it.