### PR TITLE
Shortcuts fix

### DIFF
--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -879,7 +879,9 @@ namespace Rise {
 
   async function Revealer(
     panel: NotebookPanel,
-    selected_slide: [number, number]
+    selected_slide: [number, number],
+    commands: CommandRegistry,
+    trans: TranslationBundle
   ): Promise<void> {
     document.body.classList.add('rise-enabled');
 
@@ -988,7 +990,8 @@ namespace Rise {
         36: null, // Home - first slide disabled (will be set in custom keys)
         38: null, // up arrow disabled
         40: null, // down arrow disabled
-        66: null, // b, black pause disabled, use period or forward slash
+        66: null, // b, black pause disabled, use period or forward slash -> using b event now
+        68: null, // d, scancode disabled, now used manually for downloading chalkboard
         70: null, // disable fullscreen inside the slideshow, makes codemirror unreliable
         72: null, // h, left disabled
         74: null, // j, down disabled
@@ -998,9 +1001,13 @@ namespace Rise {
         79: null, // o disabled
         80: null, // p, up disabled
         84: null, // t, modified in the custom notes plugin.
-        87: null, // w, toggle overview
-        // is it ok?
-        188: toggleAllRiseButtons // comma, hard-wired to toggleAllRiseButtons
+        86: null, // v, copy cell/blackscreen disabled
+        188: null, // comma, hard-wired to toggleAllRiseButtons (disabled, it's 'h' for help instead)
+        190: null, // scancode for blackscreen disabled, it's 'l' instead
+        191: null, // disabled for less confusion
+        219: null, // '' (and it blackened the screen without toggling)
+        220: null, // ''
+        221: null // ''
       },
       plugins: []
     };
@@ -1063,6 +1070,85 @@ namespace Rise {
       isRevealInitialized = true;
     }
 
+    //Keyboard shortcuts specific to RISE (add more shortcuts here manually):    
+    document.addEventListener('keydown', (event: KeyboardEvent) => {
+    if (!document.body.classList.contains('rise-enabled')) return;    //if slides are not opened, do nothing
+
+    const k = event.key;
+    const isKey = 
+      k === 'l' || k === 'L' ||
+      k === 'h' || k === 'H' ||
+      k === 'f' || k === 'F' ||
+      k === 's' || k === 'S' ||
+      k === 'q' || k === 'Q' ||
+      k === 'd' || k === 'D' ||
+      k === ' ' || k === ']' ||
+      k === '[' || k === 'H' ||
+      k === '=' || k === '-' ||
+      k === '?';
+
+    if (!isKey) return;
+
+    event.stopImmediatePropagation();
+    event.preventDefault();
+    switch (event.key) {
+      case '?':
+        displayRiseHelp(commands, trans);
+        break;
+
+      case 'h':
+      case 'H':
+        toggleAllRiseButtons();
+        break;
+
+      case 'f':
+      case 'F':
+        fullscreenHelp();
+        break;
+
+      case 'l':
+      case 'l':
+        Reveal.togglePause();
+        break;
+      
+      case ' ':
+        event.shiftKey ? Reveal.prev() : Reveal.next();
+        break;
+
+      case '[': //toggle full size chalkboard
+        (window as any).RevealChalkboard?.toggleChalkboard();
+        break;
+
+      case ']': //toggle notes chalkboard
+        (window as any).RevealChalkboard?.toggleNotesCanvas();
+        break;
+
+      case 's': //cycle to next pen color
+      case 'S':
+        (window as any).RevealChalkboard?.colorNext();
+        break;
+      
+      case 'q': //cycle to previous pen color
+      case 'Q':
+        (window as any).RevealChalkboard?.colorPrev();
+        break;
+
+      case '=': //reset chalkboard data on current slide
+        (window as any).RevealChalkboard?.reset();
+        break;
+
+      case '-': //clear full size chalkboard
+        (window as any).RevealChalkboard?.clear();
+        break;
+
+      case 'd':
+      case 'D':
+        (window as any).RevealChalkboard?.download();
+        break;
+    }
+    }, true);
+
+
     Reveal.addEventListener('ready', event => {
       Unselecter(panel.content);
       // check and set the scrolling slide when you start the whole thing
@@ -1093,7 +1179,7 @@ namespace Rise {
 
     if (!complete_config.show_buttons_on_startup) {
       /* safer, and nicer too, to wait for reveal extensions to start */
-      setTimeout(toggleAllRiseButtons, 2000);
+      setTimeout(toggleAllRiseButtons, 10000);
     }
 
     panel.content.activeCellChanged.connect((sender, cell) => {
@@ -1124,7 +1210,7 @@ namespace Rise {
     // Preparing the new reveal-compatible structure
     const selected_slide = markupSlides(notebook);
     // Adding the reveal stuff
-    Revealer(panel, selected_slide);
+    Revealer(panel, selected_slide, commands, trans);
     // Minor modifications for usability
     addHelpButton(panel, commands, trans);
   }
@@ -1171,10 +1257,10 @@ namespace Rise {
     ${helpListItem(CommandIDs.riseLastSlide)}
     ${helpListItem(CommandIDs.riseToggleOverview)}
     ${helpListItem(CommandIDs.riseNotesOpen)}
-    <li><kbd>${CommandRegistry.formatKeystroke(',')}</kbd>: ${
+    <li><kbd>${CommandRegistry.formatKeystroke('H')}</kbd>: ${
       helpStrings[CommandIDs.riseToggleAllButtons]
     }</li>
-    <li><kbd>${CommandRegistry.formatKeystroke('/')}</kbd>: ${trans.__(
+    <li><kbd>${CommandRegistry.formatKeystroke('L')}</kbd>: ${trans.__(
       'black screen'
     )}</li>
     <li><strong>${trans.__('less useful')}:</strong></li>

--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -1003,7 +1003,7 @@ namespace Rise {
         84: null, // t, modified in the custom notes plugin.
         87: null, // w, toggle overview
         // is it ok?
-        188: toggleAllRiseButtons, // comma, hard-wired to toggleAllRiseButtons
+        188: toggleAllRiseButtons // comma, hard-wired to toggleAllRiseButtons
       },
       plugins: []
     };
@@ -1296,7 +1296,7 @@ namespace Rise {
       title: trans.__('Reveal Shortcuts Help'),
       body: new Widget({ node }),
       buttons: [Dialog.warnButton({ label: trans.__('OK') })],
-      host: document.querySelector('.reveal') as HTMLElement  //Dialog rendered in .reveal, so it's also visible on fullscreen
+      host: document.querySelector('.reveal') as HTMLElement //!!!
     });
   }
 

--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -1066,6 +1066,52 @@ namespace Rise {
       isRevealInitialized = true;
     }
 
+    Reveal.addEventListener('ready', event => {
+      Unselecter(panel.content);
+      // check and set the scrolling slide when you start the whole thing
+      setScrollingSlide();
+      autoSelectHook(panel.content);
+    });
+
+    Reveal.addEventListener('slidechanged', event => {
+      Unselecter(panel.content);
+      // check and set the scrolling slide every time the slide change
+      setScrollingSlide();
+      autoSelectHook(panel.content);
+    });
+
+    Reveal.addEventListener('fragmentshown', event => {
+      autoSelectHook(panel.content);
+    });
+    Reveal.addEventListener('fragmenthidden', event => {
+      autoSelectHook(panel.content);
+    });
+
+    // Sync when an output is generated.
+    setupOutputObserver();
+
+    // Setup the starting slide
+    setStartingSlide(selected_slide);
+    addHeaderFooterOverlay();
+
+    if (!complete_config.show_buttons_on_startup) {
+      /* safer, and nicer too, to wait for reveal extensions to start */
+      setTimeout(toggleAllRiseButtons, 5000);  // Question mark disappears 5 seconds after opening slideshow
+    }
+
+    panel.content.activeCellChanged.connect((sender, cell) => {
+      // Move to active cell
+      if (!cell) {
+        return;
+      }
+      const slides = Reveal.getSlides();
+      const slide = slides.find(s => s.contains(cell.node));
+      if (slide) {
+        const i = Reveal.getIndices(slide as HTMLElement);
+        Reveal.slide(i.h, i.v, i.f);
+      }
+    });
+
     /* ! ! ! THE FOLLOWING KEYBOARD-EVENT CODE BLOCK BELONGS BENEATH THE IMPROVED CHALKBOARD ! ! !
     Keyboard shortcuts specific to RISE (add more shortcuts here manually):  
     */  
@@ -1138,52 +1184,6 @@ namespace Rise {
          break;
       }
     }, true);
-
-    Reveal.addEventListener('ready', event => {
-      Unselecter(panel.content);
-      // check and set the scrolling slide when you start the whole thing
-      setScrollingSlide();
-      autoSelectHook(panel.content);
-    });
-
-    Reveal.addEventListener('slidechanged', event => {
-      Unselecter(panel.content);
-      // check and set the scrolling slide every time the slide change
-      setScrollingSlide();
-      autoSelectHook(panel.content);
-    });
-
-    Reveal.addEventListener('fragmentshown', event => {
-      autoSelectHook(panel.content);
-    });
-    Reveal.addEventListener('fragmenthidden', event => {
-      autoSelectHook(panel.content);
-    });
-
-    // Sync when an output is generated.
-    setupOutputObserver();
-
-    // Setup the starting slide
-    setStartingSlide(selected_slide);
-    addHeaderFooterOverlay();
-
-    if (!complete_config.show_buttons_on_startup) {
-      /* safer, and nicer too, to wait for reveal extensions to start */
-      setTimeout(toggleAllRiseButtons, 5000);  // Question mark disappears 5 seconds after opening slideshow
-    }
-
-    panel.content.activeCellChanged.connect((sender, cell) => {
-      // Move to active cell
-      if (!cell) {
-        return;
-      }
-      const slides = Reveal.getSlides();
-      const slide = slides.find(s => s.contains(cell.node));
-      if (slide) {
-        const i = Reveal.getIndices(slide as HTMLElement);
-        Reveal.slide(i.h, i.v, i.f);
-      }
-    });
   }
 
   function Unselecter(notebook: Notebook) {

--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -1001,13 +1001,9 @@ namespace Rise {
         79: null, // o disabled
         80: null, // p, up disabled
         84: null, // t, modified in the custom notes plugin.
-        86: null, // v, copy cell/blackscreen disabled
-        188: null, // comma, hard-wired to toggleAllRiseButtons (disabled, it's 'h' for help instead)
-        190: null, // scancode for blackscreen disabled, it's 'l' instead
-        191: null, // disabled for less confusion
-        219: null, // '' (and it blackened the screen without toggling)
-        220: null, // ''
-        221: null // ''
+        87: null, // w, toggle overview
+        // is it ok?
+        188: toggleAllRiseButtons, // comma, hard-wired to toggleAllRiseButtons
       },
       plugins: []
     };
@@ -1070,84 +1066,78 @@ namespace Rise {
       isRevealInitialized = true;
     }
 
-    //Keyboard shortcuts specific to RISE (add more shortcuts here manually):    
+    /* ! ! ! THE FOLLOWING KEYBOARD-EVENT CODE BLOCK BELONGS BENEATH THE IMPROVED CHALKBOARD ! ! !
+    Keyboard shortcuts specific to RISE (add more shortcuts here manually):  
+    */  
     document.addEventListener('keydown', (event: KeyboardEvent) => {
-    if (!document.body.classList.contains('rise-enabled')) return;    //if slides are not opened, do nothing
+      if (!document.body.classList.contains('rise-enabled')) return;    //if slides are not opened, do nothing
 
-    const k = event.key;
-    const isKey = 
-      k === 'l' || k === 'L' ||
-      k === 'h' || k === 'H' ||
-      k === 'f' || k === 'F' ||
-      k === 's' || k === 'S' ||
-      k === 'q' || k === 'Q' ||
-      k === 'd' || k === 'D' ||
-      k === ' ' || k === ']' ||
-      k === '[' || k === 'H' ||
-      k === '=' || k === '-' ||
-      k === '?';
+      const k = event.key;
+      const isKey =
+        k === 'f' || k === 'F' ||
+        k === 'l' || k === 'L' ||
+        k === 'p' || k === 'P' ||  
+        k === 'd' || k === 'D' ||
+        k === 's' || k === 'S' ||
+        k === 'q' || k === 'Q' ||
+        k === '.' ||
+        k === '?' ||
+        k === '=' ||
+        k === '-';
+        
+      if (!isKey) return;
 
-    if (!isKey) return;
+      event.stopImmediatePropagation(); //prevents other event-listeners to be executed for the same elements
+      event.preventDefault(); //prevents defult action from browser
+      switch (k) {
 
-    event.stopImmediatePropagation();
-    event.preventDefault();
-    switch (event.key) {
-      case '?':
-        displayRiseHelp(commands, trans);
-        break;
+        case '?':
+          displayRiseHelp(commands, trans);
+          break;
 
-      case 'h':
-      case 'H':
-        toggleAllRiseButtons();
-        break;
+        case '.':
+          Reveal.togglePause();
+          break;
 
-      case 'f':
-      case 'F':
-        fullscreenHelp();
-        break;
+        case 'f': //open fullscreen
+        case 'F':
+          fullscreenHelp();
+          break;
 
-      case 'l':
-      case 'l':
-        Reveal.togglePause();
-        break;
+        case 'l': //open (not working) chalkboard
+        case 'L':
+          (window as any).RevealChalkboard?.toggleChalkboard();
+          break;
+
+        case 'p': //open working chalkboard
+        case 'P': 
+          (window as any).RevealChalkboard?.toggleNotesCanvas();
+          break;
+
+        case '=': //reset chalkboard data on current slide
+          (window as any).RevealChalkboard?.reset();
+          break;
+
+        case '-': //clear full size chalkboard
+          (window as any).RevealChalkboard?.clear();
+          break;
+
+        case 'd': //download chalkboard data
+        case 'D':
+          (window as any).RevealChalkboard?.download();
+          break;
       
-      case ' ':
-        event.shiftKey ? Reveal.prev() : Reveal.next();
-        break;
+        case 's': //next chalkboard color
+        case 'S':
+          (window as any).RevealChalkboard?.colorNext();
+          break;
 
-      case '[': //toggle full size chalkboard
-        (window as any).RevealChalkboard?.toggleChalkboard();
-        break;
-
-      case ']': //toggle notes chalkboard
-        (window as any).RevealChalkboard?.toggleNotesCanvas();
-        break;
-
-      case 's': //cycle to next pen color
-      case 'S':
-        (window as any).RevealChalkboard?.colorNext();
-        break;
-      
-      case 'q': //cycle to previous pen color
-      case 'Q':
-        (window as any).RevealChalkboard?.colorPrev();
-        break;
-
-      case '=': //reset chalkboard data on current slide
-        (window as any).RevealChalkboard?.reset();
-        break;
-
-      case '-': //clear full size chalkboard
-        (window as any).RevealChalkboard?.clear();
-        break;
-
-      case 'd':
-      case 'D':
-        (window as any).RevealChalkboard?.download();
-        break;
-    }
+        case 'q': //previous chalkboard color
+        case 'Q':
+          (window as any).RevealChalkboard?.colorPrev();
+         break;
+      }
     }, true);
-
 
     Reveal.addEventListener('ready', event => {
       Unselecter(panel.content);
@@ -1179,7 +1169,7 @@ namespace Rise {
 
     if (!complete_config.show_buttons_on_startup) {
       /* safer, and nicer too, to wait for reveal extensions to start */
-      setTimeout(toggleAllRiseButtons, 10000);
+      setTimeout(toggleAllRiseButtons, 5000);  // Question mark disappears 5 seconds after opening slideshow
     }
 
     panel.content.activeCellChanged.connect((sender, cell) => {
@@ -1257,10 +1247,13 @@ namespace Rise {
     ${helpListItem(CommandIDs.riseLastSlide)}
     ${helpListItem(CommandIDs.riseToggleOverview)}
     ${helpListItem(CommandIDs.riseNotesOpen)}
-    <li><kbd>${CommandRegistry.formatKeystroke('H')}</kbd>: ${
+    <li><kbd>${CommandRegistry.formatKeystroke('F')}</kbd>: ${trans.__(
+      'open fullscreen'
+    )}</li>
+    <li><kbd>${CommandRegistry.formatKeystroke(',')}</kbd>: ${
       helpStrings[CommandIDs.riseToggleAllButtons]
     }</li>
-    <li><kbd>${CommandRegistry.formatKeystroke('L')}</kbd>: ${trans.__(
+    <li><kbd>${CommandRegistry.formatKeystroke('.')}</kbd>: ${trans.__(
       'black screen'
     )}</li>
     <li><strong>${trans.__('less useful')}:</strong></li>
@@ -1302,7 +1295,8 @@ namespace Rise {
     await showDialog({
       title: trans.__('Reveal Shortcuts Help'),
       body: new Widget({ node }),
-      buttons: [Dialog.warnButton({ label: trans.__('OK') })]
+      buttons: [Dialog.warnButton({ label: trans.__('OK') })],
+      host: document.querySelector('.reveal') as HTMLElement  //Dialog rendered in .reveal, so it's also visible on fullscreen
     });
   }
 

--- a/packages/lab/schema/plugin.json
+++ b/packages/lab/schema/plugin.json
@@ -105,7 +105,7 @@
     },
     {
       "command": "RISE:chalkboard-download",
-      "keys": ["\\"],
+      "keys": ["D"],
       "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {

--- a/packages/lab/schema/plugin.json
+++ b/packages/lab/schema/plugin.json
@@ -85,12 +85,12 @@
     },
     {
       "command": "RISE:chalkboard-toggleChalkboard",
-      "keys": ["["],
+      "keys": ["l"],
       "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {
       "command": "RISE:chalkboard-toggleNotesCanvas",
-      "keys": ["]"],
+      "keys": ["p"],
       "selector": ".lm-Widget.reveal .jp-mod-commandMode"
     },
     {


### PR DESCRIPTION
# Important
Since this PR touches shortcut handling, so I recommend merging it before the following PRs:
* Add improved chalkboard palette UI #132
* added font size menu that works #133

# Summary
* Switched chalkboard toggles from '[' / ']' to 'L' / 'P'
* Help dialog is now rendered inside `.reveal`, making it visible in fullscreen mode
* Help button automatically disappears after 5 seconds when opening the slideshow, if not toggled manually

# Changes
## rise\packages\application\src\plugins\rise.ts:
* Added a global keyboard handler using  
  'document.addEventListener('keydown', (event: KeyboardEvent) => { ... }, true)'
* Updated the help dialog rendering to ensure fullscreen visibility
* Adjusted the auto-hide timer for the help button to 5 seconds

## rise\packages\lab\schema\plugin.json:
* Updated the displayed chalkboard download shortcut from `\` to `D` to match actual behavior
* Changed chalkboard toggle shortcuts to `L` (chalkboard) and `P` (notes canvas)

# Updated Help-Menu
![5B5A3382-449F-4940-BA82-A833E48B86A0](https://github.com/user-attachments/assets/de42f306-b575-469a-b063-30601998c46a)
![7EEAEEBC-C23E-42EF-B444-8D174F364174](https://github.com/user-attachments/assets/c1fc85be-135a-44ef-8037-62ab20498ab3)

# Testing
* Start slideshow in Jupyter
* Verify that the help button in the bottom-left corner disappears after 5 seconds
* Open the help menu by clicking the help button or pressing `?`
* Verify that all listed shortcuts work as described